### PR TITLE
Making example run again on current SageMaker notebooks & and enable usage of GPU training instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ The skin cancer predictive model uses Amazon Sagemaker architecture which includ
 To run the skin cancer model using MONAI follow the steps below:
 
 <ol>
-<li>Create an S3 bucket in your account.
+<li>Create an S3 bucket in your account and add an empty folder to it. 
 <li>Navigate to the dataset download at <a href="https://dataverse.harvard.edu/dataset.xhtml?persistentId=doi:10.7910/DVN/DBW86T">HAM10000</a>.
 <li>Select "Access Dataset" in top right, and review the license Creative Commons Attribution-NonCommercial 4.0 International Public License. 
-<li>If you accept license, then select "Original Format Zip" and upload the zip to the S3 bucket created in previous steps.
+<li>If you accept license, then select "Original Format Zip" and upload the zip to the folder in the S3 bucket you created in the previous steps.
 <li>Navigate to Amazon Sagemaker in the same account to create a Jupyter Notebook instance.
 <li>Under Notebook > Notebook instances select Create Notebook instance. Fill in the name (ex. skin-cancer-notebook) and instance type ml.t2.medium and select volume size of 100 GB.
 <li>The Notebook will need permissions to call other services including SageMaker and S3.  Choose an existing role or create a role with the AmazonSageMakerFull Access IAM role.  

--- a/monai_skin_cancer.ipynb
+++ b/monai_skin_cancer.ipynb
@@ -162,7 +162,7 @@
    "source": [
     "## Run training in SageMaker\n",
     "\n",
-    "The `PyTorch` class allows us to run our training function as a training job on SageMaker infrastructure.  We need to configure it with our training script, an IAM role, the number of training instances, the training instance type, and hyperparameters.  In this case we are going to run our training job on ```ml.c5.9xlarge``` instance.  But this example can be ran on one or multiple, cpu or gpu instances ([full list of available instances](https://aws.amazon.com/sagemaker/pricing/instance-types/)).  The hyperparameters parameter is a dict of values that will be passed to your training script -- you can see how to access these values in the ```monai_skin_cancer.py``` script above."
+    "The `PyTorch` class allows us to run our training function as a training job on SageMaker infrastructure.  We need to configure it with our training script, an IAM role, the number of training instances, the training instance type, and hyperparameters.  In this case we are going to run our training job on ```ml.p3.8xlarge``` instance.  But this example can be ran on one or multiple, cpu or gpu instances ([full list of available instances](https://aws.amazon.com/sagemaker/pricing/instance-types/)).  The hyperparameters parameter is a dict of values that will be passed to your training script -- you can see how to access these values in the ```monai_skin_cancer.py``` script above."
    ]
   },
   {
@@ -179,7 +179,7 @@
     "                    framework_version='1.5.0',\n",
     "                    py_version='py3',\n",
     "                    instance_count=1,\n",
-    "                    instance_type='ml.c5.9xlarge',\n",
+    "                    instance_type='ml.p3.8xlarge',\n",
     "                    hyperparameters={\n",
     "                        'backend': 'gloo',\n",
     "                        'epochs': 30\n",

--- a/source/monai_skin_cancer.py
+++ b/source/monai_skin_cancer.py
@@ -5,7 +5,6 @@ import argparse
 import json
 import logging
 import os
-import sagemaker_containers
 import sys
 import torch
 import torch.distributed as dist

--- a/source/monai_skin_cancer.py
+++ b/source/monai_skin_cancer.py
@@ -197,6 +197,7 @@ def train(args):
     
     #test data:classification report
     model.load_state_dict(torch.load('best_metric_model.pth'))
+    model.to(device)
     model.eval()
     y_true = list()
     y_pred = list()

--- a/source/transform_data.ipynb
+++ b/source/transform_data.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df_data = pd.read_csv(base_dir+skin_cancer_files+'/HAM10000_metadata.csv')\n",
+    "df_data = pd.read_csv(base_dir+skin_cancer_files+'/HAM10000_metadata')\n",
     "\n",
     "df_data.head()"
    ]


### PR DESCRIPTION
*Issue description*

Users cannot run/reproduce the SageMaker/MONAI example in a current plain vanilla SageMaker classic notebook because of the issues described below. In addition, switching from a CPU to a GPU training instance causes an error. All issues/errors have been fixed and are described in detail below. 

*Description of changes:*

* In the README, added instructions to store the HAM10000 dataset in a folder/folder structure. When you store it on S3 root level, the `transform_data` notebook will fail to execute because of the following line of code: `s3.download_file(skin_cancer_bucket, skin_cancer_bucket_path+'/'+skin_cancer_files_ext, base_dir+skin_cancer_files_ext)`. Like this, configuring `SKIN_CANCER_BUCKET_PATH` in `set.env` to be the S3 root simply cannot work.  
* In the `monai_skin_cancer.py` training script, removed the `import sagemaker_containers` statement, which caused an error because the package has been deprecated in favor of the [SageMaker Training Toolkit](https://github.com/aws/sagemaker-containers#warning-this-package-has-been-deprecated-please-use-the-sagemaker-training-toolkit-for-model-training-and-the-sagemaker-inference-toolkit-for-model-serving). 
* In the `transform_data` notebook, the line `df_data = pd.read_csv(base_dir+skin_cancer_files+'/HAM10000_metadata.csv')` caused an error and I had to replace it with `df_data = pd.read_csv(base_dir+skin_cancer_files+'/HAM10000_metadata')` as the CSV metadata file is actually generated and stored without the file extension on the EBS volume. 
* In the `monai_skin_cancer.py` training script, added `model.to(device)` after loading the model to prevent `RuntimeError: Input type (torch.cuda.FloatTensor) and weight type (torch.FloatTensor) should be the same` when choosing GPU training instances
* In `monai_skin_cancer.ipynb`, switched from CPU to GPU training instance to accelerate training significantly with a moderate cost increase (ml.c.9xlarge/8h training time/$15.8 total training cost in eu-west 1 vs ml.p3.8xlarge/2h/$23.8)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
